### PR TITLE
docs: add qq-ai-bot to community resources and integration guide

### DIFF
--- a/src/use/community.md
+++ b/src/use/community.md
@@ -73,3 +73,12 @@ Author: faithleysath
 - [使用文档](https://faithleysath.github.io/napcat-sdk/)
 :::
 
+
+::: details TypeScript 自托管 QQ ↔ AI 机器人骨架：qq-ai-bot
+Author: happysnaker
+
+基于 **OneBot 11** 与 **ACP** 的自托管 QQ ↔ AI 机器人骨架，支持 **NapCat / LLOneBot**、会话持久化、进度回传与 Docker 部署。
+
+- [GitHub 仓库](https://github.com/happysnaker/qq-ai-bot)
+- [项目页](https://happysnaker.github.io/qq-ai-bot/)
+:::

--- a/src/use/integration.md
+++ b/src/use/integration.md
@@ -69,6 +69,56 @@
 
 
 
+## [qq-ai-bot](https://github.com/happysnaker/qq-ai-bot)
+
+一个面向实际部署的 QQ ↔ AI 机器人脚手架，使用 OneBot 11 对接 NapCat，并通过 ACP 兼容 agent 提供 AI 能力。
+
+默认支持私聊 / 群聊独立会话、处理进度回传、`/status` 等运维命令，更适合想把 NapCat 接到本地 agent 或自定义 AI 工作流上的场景。
+
+1. 配置 qq-ai-bot
+
+   拉取仓库并准备配置：
+
+   ```bash
+   git clone https://github.com/happysnaker/qq-ai-bot.git
+   cd qq-ai-bot
+   npm install
+   cp .env.example .env
+   cp examples/group-rules.example.json examples/group-rules.local.json
+   ```
+
+   最少需要确认这些配置：
+
+   - `ONEBOT_MODE=reverse`
+   - `ONEBOT_ACCESS_TOKEN=你的 token`
+   - `ONEBOT_REVERSE_WS_HOST=0.0.0.0`
+   - `ONEBOT_REVERSE_WS_PORT=16700`
+   - `ONEBOT_REVERSE_WS_PATH=/onebot/v11/ws`
+   - `ACP_AGENT_COMMAND` / `ACP_AGENT_ARGS_JSON` / `ACP_AGENT_WORKDIR` 已按你的 agent 实际情况填写
+
+   然后启动 qq-ai-bot：
+
+   ```bash
+   npm run dev
+   ```
+
+2. 配置 NapCat
+
+   在 NapCat WebUI 页面选择 网络配置 → 新建 → WebSocket 客户端，URL 填入 `ws://127.0.0.1:16700/onebot/v11/ws`。
+
+   如果配置了 token，请和 `ONEBOT_ACCESS_TOKEN` 保持一致。
+
+   > 如果你是用 Docker 部署的 qq-ai-bot，则 URL 应为 `ws://qq-ai-bot:16700/onebot/v11/ws`
+
+3. 验证连接
+
+   连接成功后，可在 QQ 中给机器人发送 `/ping` 或 `/status` 测试链路是否打通。默认群聊场景需要 `@机器人` 才会触发。
+
+   如果你暂时还没有现成的 ACP agent，也可以先参考项目自带的 mock agent 或 Docker 演示栈把链路跑通。
+
+- 项目主页：https://happysnaker.github.io/qq-ai-bot/
+- 快速开始：https://github.com/happysnaker/qq-ai-bot/blob/main/docs/getting-started.md
+
 ## OlivOS
 
 支持正向和反向 WS 以及 http 详见 [文档](https://doc.olivos.wiki/)


### PR DESCRIPTION
## Summary
- add `qq-ai-bot` to the NapCat community resources page
- add a dedicated `qq-ai-bot` section to the integration guide
- position it as a TypeScript self-hosted QQ ↔ AI bot scaffold built on OneBot 11 + ACP

## Why
`qq-ai-bot` is relevant for the NapCat ecosystem because it gives developers a deployment-oriented TypeScript starting point for NapCat-connected AI bot workflows rather than another low-level SDK entry.

The integration section also makes the exact reverse-WS wiring path explicit for users who want to connect NapCat to an ACP-compatible local agent.